### PR TITLE
[BASHFUL] store new registry urls for updating later

### DIFF
--- a/bin/bashful
+++ b/bin/bashful
@@ -29,6 +29,11 @@ manfiest.addGist () {
   ")
   echo "$data" > "$__bash_suite_filesys/installation-manifest.json"
 }
+manfiest.getRegistryUrl () {
+  json "$__bash_suite_filesys/installation-manifest.json" "
+    console.log((\$).registries['$1'] || '')
+  "
+}
 manfiest.removeGist () {
   data=$(json "$__bash_suite_filesys/installation-manifest.json" "
     \$.fromGists = \$.fromGists.filter(x => x.name !== '$1');
@@ -81,14 +86,29 @@ registry.addRegistryList () {
   gist_hash=$(basename "$_url" | sed -e 's#.git##g');
   echo "$gist_hash: $_url";
   cd $__TMP__;
+  rm -rf "$gist_hash";
   git clone "$_url"; 
   cd "$gist_hash";
   file=$(ls)
-  data=$(json $file "
+
+  # record in the registry
+  regData=$(json $file "
     let registry = require('$__bash_suite_filesys/registry.json');
     console.log(JSON.stringify(Object.assign({}, registry, \$)))
   ")
-  echo "$data" > "$__bash_suite_filesys/registry.json"
+  echo "$regData" > "$__bash_suite_filesys/registry.json"
+  
+  # record in the manifest
+  manData=$(json $file "
+    let manifest = require('$__bash_suite_filesys/installation-manifest.json');
+    let url = '$_url'; 
+    let registries = {}; 
+    Object.keys($).forEach(k => registries[k] = url);
+    manifest.registries = Object.assign({}, manifest.registries, registries)
+    console.log(JSON.stringify(manifest))
+  ")
+  echo "$manData" > "$__bash_suite_filesys/installation-manifest.json"
+
   rm -rf "$gist_hash";
   echo "Successfully add $file to the main registry"
 }
@@ -183,12 +203,17 @@ elif [ "$1" == "uninstall" ]; then
 #:   Install a gist as an executable
 #: bashful gist add <new registry url>
 #:   Add a JSON registry list to bashful's main registry
+#: bashful gist update-registry <registry name>
+#:   Update the list of a currently installed registry
 #: bashful gist info [<name or search>]
 #:   List all gists in bashful's registry that are available to install
 #:######################################################
 elif [ "$1" == "gist" ]; then
   if [ "$2" == "add" ]; then
     registry.addRegistryList $3
+  elif [ "$2" == "update-registry" ]; then
+    _url=`manfiest.getRegistryUrl $3`
+    registry.addRegistryList "$_url"
   elif [ "$2" == "info" ]; then
     registry.query $3
   elif [ "$2" == "install" ]; then

--- a/docs/bashful.md
+++ b/docs/bashful.md
@@ -43,6 +43,12 @@ To combine another registry with the main bashful registry, run the following co
 bashful gist add <url to gist hosting additional registry>
 ```
 
+To update a registry listing on your machine, run the following command. It will grab the latest data so that you can access it via `bashful gist info`.
+
+```sh
+bashful gist update-registry <name of the registry>
+```
+
 ### How to Set Up a Bashful Gist Registry
 
 <details>

--- a/filesys/installation-manifest.json
+++ b/filesys/installation-manifest.json
@@ -5,5 +5,6 @@
     "inc",
     "json"
   ],
-  "fromGists": []
+  "fromGists": [],
+  "registries": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bashful",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Install my custom suite of terminal tools for Bash in OSX",
   "main": "install.sh",
   "scripts": {

--- a/test/bashful_test.sh
+++ b/test/bashful_test.sh
@@ -56,6 +56,10 @@ div --
 bashful list
 
 div --
+run bashful gist update-registry BashfulTest
+bashful gist info
+
+div --
 run bashful update
 run bashful update bacon
 

--- a/test/index.sh
+++ b/test/index.sh
@@ -54,3 +54,6 @@ for file in $testFiles; do
   echo;
   echo;
 done
+
+echo -e "\033[1;90mTests complete for: ${testFiles[@]}\033[0m" >&2; # dark grey
+echo -e "\033[1;32mAll Tests Passed. Great job, you did not break anything (yet...)\033[0m\n" # bright green

--- a/test/snapshots/bashful_test.sh.snapshot
+++ b/test/snapshots/bashful_test.sh.snapshot
@@ -156,6 +156,23 @@ Bashful Tools Installed from Gists:
 
 ----------------------------------------------------------------
 ________________________________________________________________________________________________
+RUNNING > 'bashful gist update-registry BashfulTest'
+................................................................
+f1cdcb80c1666788cd5337f0d66bb058: https://gist.github.com/kyle-west/f1cdcb80c1666788cd5337f0d66bb058.git
+Successfully add BashfulTest.registry.json to the main registry
+................................................................
+________________________________________________________________________________________________
+┌─────────┬─────────────┬───────────────┬────────────────────────────────────────────────────────────────────────┐
+│ (index) │   package   │   registry    │                              description                               │
+├─────────┼─────────────┼───────────────┼────────────────────────────────────────────────────────────────────────┤
+│    0    │   'prune'   │  'standard'   │           'Remove all the Git branches that match a pattern'           │
+│    1    │ 'killport'  │  'standard'   │         'Kill a process that is listening on a specific port'          │
+│    2    │ 'workspace' │  'standard'   │ '"Favorite" a directory and quickly navigate to it using `ws [name]`.' │
+│    3    │   'bacon'   │ 'BashfulTest' │               'Test the `bashful gist install` program'                │
+└─────────┴─────────────┴───────────────┴────────────────────────────────────────────────────────────────────────┘
+Install a gist package by running `bashful gist install <package-name>`
+----------------------------------------------------------------
+________________________________________________________________________________________________
 RUNNING > 'bashful update'
 ................................................................
 Gathering latest files from GitHub
@@ -211,6 +228,8 @@ RUNNING > 'bashful'
    Install a gist as an executable
  bashful gist add <new registry url>
    Add a JSON registry list to bashful's main registry
+ bashful gist update-registry <registry name>
+   Update the list of a currently installed registry
  bashful gist info [<name or search>]
    List all gists in bashful's registry that are available to install
 
@@ -246,6 +265,8 @@ Unknown Command: "unknown-command"
    Install a gist as an executable
  bashful gist add <new registry url>
    Add a JSON registry list to bashful's main registry
+ bashful gist update-registry <registry name>
+   Update the list of a currently installed registry
  bashful gist info [<name or search>]
    List all gists in bashful's registry that are available to install
 


### PR DESCRIPTION
Add support for `bashful gist add <url>` to save the URL in the manifest so that later, the user can choose to update the registry listing without having to look it up.

>To update a registry listing on your machine, run the following command. It will grab the latest data so that you can access it via `bashful gist info`.
>
>```sh
>bashful gist update-registry <name of the registry>
>```

Also, I updated some of the test output to be more clear when things pass.